### PR TITLE
修改工单页的分页链接显示和回滚SQL显示

### DIFF
--- a/sql/inception.py
+++ b/sql/inception.py
@@ -108,7 +108,8 @@ class InceptionDao(object):
             sqlBack = "select rollback_statement from %s.%s where opid_time='%s'" % (backupDbName, tableName, opidTime)
             listBackup = self._fetchall(sqlBack, self.inception_remote_backup_host, self.inception_remote_backup_port, self.inception_remote_backup_user, self.inception_remote_backup_password, '')
             if listBackup is not None and len(listBackup) !=0:
-                listBackupSql.append(listBackup[0][0])
+                for rownum in range(len(listBackup)):
+                    listBackupSql.append(listBackup[rownum][0])
         return listBackupSql
             
 

--- a/sql/static/allWorkflow.html
+++ b/sql/static/allWorkflow.html
@@ -102,6 +102,7 @@
 				<li class="active">
 					 <a href="/allworkflow/?pageNo={{pageNo|add:"0"}}&navStatus={{navStatus}}">{{pageNo|add:"1"}}</a>
 				</li>
+				{% if listWorkflow|length >= PAGE_LIMIT %}
 				<li>
 					 <a href="/allworkflow/?pageNo={{pageNo|add:"1"}}&navStatus={{navStatus}}">{{pageNo|add:"2"}}</a>
 				</li>
@@ -117,6 +118,7 @@
 				<li>
 					 <a href="/allworkflow/?pageNo={{pageNo|add:"1"}}&navStatus={{navStatus}}">后一页</a>
 				</li>
+				{% endif %}
 			</ul>
 			</div>
 {% endblock content%}

--- a/sql/static/login.html
+++ b/sql/static/login.html
@@ -33,7 +33,7 @@
 						<hr/>
 						<div class="form-group">
 							<div class="col-sm-offset-2 col-sm-10">
-								 <div class="btn btn-primary" id="btnLogin">登录</div>
+								 <button class="btn btn-primary" id="btnLogin" type="button">登录</button>
 							</div>
 						</div>
 					</form>

--- a/sql/views.py
+++ b/sql/views.py
@@ -62,7 +62,7 @@ def authenticate(request):
 #首页，也是查看所有SQL工单页面，具备翻页功能
 def allworkflow(request):
     #一个页面展示
-    PAGE_LIMIT = 12
+    PAGE_LIMIT = 2
 
     pageNo = 0
     navStatus = ''
@@ -118,7 +118,7 @@ def allworkflow(request):
         return render(request, 'error.html', context)
 
 
-    context = {'currentMenu':'allworkflow', 'listWorkflow':listWorkflow, 'pageNo':pageNo, 'navStatus':navStatus}
+    context = {'currentMenu':'allworkflow', 'listWorkflow':listWorkflow, 'pageNo':pageNo, 'navStatus':navStatus, 'PAGE_LIMIT':PAGE_LIMIT}
     return render(request, 'allWorkflow.html', context)
 
 #提交SQL的页面

--- a/sql/views.py
+++ b/sql/views.py
@@ -62,7 +62,7 @@ def authenticate(request):
 #首页，也是查看所有SQL工单页面，具备翻页功能
 def allworkflow(request):
     #一个页面展示
-    PAGE_LIMIT = 2
+    PAGE_LIMIT = 12
 
     pageNo = 0
     navStatus = ''

--- a/sql/views.py
+++ b/sql/views.py
@@ -329,7 +329,7 @@ def rollback(request):
         return render(request, 'error.html', context)
     workflowId = int(workflowId)
     listBackupSql = inceptionDao.getRollbackSqlList(workflowId)
-   
+
     context = {'listBackupSql':listBackupSql}
     return render(request, 'rollback.html', context)
 


### PR DESCRIPTION
[查看历史工单]页，增加功能：当某个分页的数据条数< PAGE_LIMIT时，不显示后面的分页链接
[修改]：修正“查看回滚SQL”时多条SQL只显示一条的问题
[修改]：修改登录按钮，使之能够被TABLE键搜索到