### PR TITLE
增加副审核人feature

### DIFF
--- a/sql/models.py
+++ b/sql/models.py
@@ -10,7 +10,7 @@ from .aes_decryptor import Prpcrypt
 #2.审核人：可以审核并执行SQL上线单的管理者、高级工程师、系统管理员们。
 class users(AbstractUser):
     display = models.CharField('显示的中文名', max_length=50)
-    role = models.CharField('角色', max_length=20, choices=(('工程师','工程师'),('审核人','审核人')), default='工程师')
+    role = models.CharField('角色', max_length=20, choices=(('工程师','工程师'),('审核人','审核人'),('副审核人','副审核人')), default='工程师')
 
     def __str__(self):
         return self.username

--- a/sql/static/detail.html
+++ b/sql/static/detail.html
@@ -2,6 +2,8 @@
 
 {% block content %}
 			<h4>单子名称：{{workflowDetail.workflow_name}}</h4>
+            <input type="hidden" id="workflowDetail_id" name="workflowid" value="{{workflowDetail.id}}">
+            <p id="date">现在时间</p>
 			<hr>	
 			<table class="table table-striped table-hover">
 				<thead>
@@ -55,7 +57,7 @@
 							{% else %}
 								<font color="red">
 							{% endif %}
-								<B>{{workflowDetail.status}}</B></font>
+								<B id="workflowDetail_status">{{workflowDetail.status}}</B></font>
 						</td>
 					</tr>
 					
@@ -91,7 +93,7 @@
 						<td>
 							{{forloop.counter}}
 						</td>
-						<td>
+						<td class="sqlString">
 							{{row.5}}
 						</td>
 						<td>
@@ -104,7 +106,16 @@
 							{{row.9}}
 						</td>
 						<td>
-							{{row.3}}
+                            {% if workflowDetail.status == "等待审核人审核" %}
+                                <div class="progress">
+                                    <div id="sql_{{forloop.counter}}" class="progress-bar" role="progressbar" aria-valuenow="60"
+                                        aria-valuemin="0" aria-valuemax="100" style="width: 0%;">
+                                        <!--<span class="sr-only">40% 完成</span>-->
+                                    </div>
+                                </div>
+                            {% else %}
+							    {{row.3}}
+                            {% endif %}
 						</td>
 					</tr>
 					{% endfor %}

--- a/sql/static/detail.html
+++ b/sql/static/detail.html
@@ -35,7 +35,7 @@
 							{{workflowDetail.engineer}}
 						</td>
 						<td>
-							{{workflowDetail.review_man}}
+							{{listAllReviewMen.0}} {{listAllReviewMen.1}}
 						</td>
 						<td>
 							{{workflowDetail.cluster_name}}
@@ -112,7 +112,7 @@
 				</tbody>
 			</table>
 			{% if workflowDetail.status == '等待审核人审核' %}
-			{% if workflowDetail.review_man == loginUser %}
+			{% if loginUser in listAllReviewMen %}
 			<form action="/execute/" method="post" style="display:inline-block;">
 				{% csrf_token %}
 				<input type="hidden" name="workflowid" value="{{workflowDetail.id}}">

--- a/sql/static/submitSql.html
+++ b/sql/static/submitSql.html
@@ -59,8 +59,8 @@
                                 </div>
                                 <div id="collapseOne" class="panel-collapse collapse in">
                                     <div class="panel-body" style="margin-left: 25px">
-                                        {% for man in subReviewMen %}
-                                            <div class="radio">
+                                        {% for man in reviewMen %}
+                                            <div class="radio" id="{{ man }}">
                                                 <input type="radio" id="radio1" name="sub_review_man" value="{{ man }}" />
                                                 <label for="radio1"> {{ man }} </label>
                                             </div>

--- a/sql/static/submitSql.html
+++ b/sql/static/submitSql.html
@@ -43,6 +43,34 @@
 					{% endfor %}
 					</select>
 				</div>
+
+                    <!--增加副审核人选项-->
+                    <div class="form-group">
+                        <div class="panel-group" id="accordion">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    <h4 class="panel-title">
+                                        <a data-toggle="collapse" data-parent="#accordion"
+                                           href="#collapseOne">
+                                            <i class="glyphicon-plus glyphicon"></i>
+                                            增加副审核人（可选)
+                                        </a>
+                                    </h4>
+                                </div>
+                                <div id="collapseOne" class="panel-collapse collapse in">
+                                    <div class="panel-body" style="margin-left: 25px">
+                                        {% for man in subReviewMen %}
+                                            <div class="radio">
+                                                <input type="radio" id="radio1" name="sub_review_man" value="{{ man }}" />
+                                                <label for="radio1"> {{ man }} </label>
+                                            </div>
+                                        {% endfor %}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
 				<div class="form-group">
                     <input type="button" id="btn-autoreview" class="btn btn-info btn-lg" value="SQL检测" />
                     <button type="reset" class="btn btn-warning">清空选项</button>

--- a/sql/static/user/js/detail.js
+++ b/sql/static/user/js/detail.js
@@ -1,0 +1,47 @@
+$(document).ready(function (){
+  var status = $("#workflowDetail_status").text();
+  if (status=="等待审核人审核"){
+    setInterval("startRequest()",1000);
+  }
+});
+
+
+
+function startRequest()
+{
+    $("#date").text((new Date()).toString());
+    var workflowid = $("#workflowDetail_id").val();
+    var sqls = sqlStrings();
+
+    for(var i = 0; i < sqls.length; i++){
+        var j = i + 1
+        sql = sqls[i];
+        $.ajax({
+            type: "post",
+            url: "/getOscPercent/",
+            dataType: "json",
+            data: {
+                workflowid: workflowid,
+                sqlString: sql,
+            },
+            complete: function () {
+            },
+            success: function (data) {
+                if (data.status == 0) {
+                    pct = data.data.percent;
+                    $("div#sql_" + j).attr("style", "width: " + pct + "%");
+                }
+            },
+            error: function () {
+            }
+        });
+        }
+}
+
+function sqlStrings() {
+    var sqls = new Array();
+    $(".sqlString").each(function(){
+      sqls.push($(this).text());
+    });
+    return sqls;
+}

--- a/sql/static/user/js/submitsql.js
+++ b/sql/static/user/js/submitsql.js
@@ -30,9 +30,8 @@ $("#btn-submitsql").click(function (){
 
 $("#review_man").change(function review_man(){
     var review_man = $(this).val();
-    $("#" + review_man).hide();
+    $("div#" + review_man).hide();
 });
-
 
 
 //增加副审核人(可选)

--- a/sql/static/user/js/submitsql.js
+++ b/sql/static/user/js/submitsql.js
@@ -27,5 +27,13 @@ $("#btn-submitsql").click(function (){
 	}
 });
 
+
+$("#review_man").change(function review_man(){
+    var review_man = $(this).val();
+    $("#" + review_man).hide();
+});
+
+
+
 //增加副审核人(可选)
 $(function () { $('#collapseOne').collapse('hide')});

--- a/sql/static/user/js/submitsql.js
+++ b/sql/static/user/js/submitsql.js
@@ -26,3 +26,6 @@ $("#btn-submitsql").click(function (){
 		formSubmit.submit();
 	}
 });
+
+//增加副审核人(可选)
+$(function () { $('#collapseOne').collapse('hide')});

--- a/sql/views.py
+++ b/sql/views.py
@@ -276,15 +276,18 @@ def execute(request):
 
             #发一封邮件
             engineer = workflowDetail.engineer
-            reviewMan = json.loads(workflowDetail.review_man)
+            reviewMans = json.loads(workflowDetail.review_man)
             workflowStatus = workflowDetail.status
             workflowName = workflowDetail.workflow_name
             objEngineer = users.objects.get(username=engineer)
-            objReviewMan = users.objects.filter(username=reviewMan)
-            strTitle = "SQL上线工单执行完毕 # " + str(workflowId)
-            strContent = "发起人：" + engineer + "\n审核人：" + reviewMan + "\n工单地址：" + url + "\n工单名称： " + workflowName +"\n执行结果：" + workflowStatus
-            mailSender.sendEmail(strTitle, strContent, [objEngineer.email])
-            mailSender.sendEmail(strTitle, strContent, getattr(settings, 'MAIL_REVIEW_DBA_ADDR'))
+            for reviewMan in reviewMans:
+                if reviewMan == "":
+                    continue
+                objReviewMan = users.objects.filter(username=reviewMan)
+                strTitle = "SQL上线工单执行完毕 # " + str(workflowId)
+                strContent = "发起人：" + engineer + "\n审核人：" + reviewMan + "\n工单地址：" + url + "\n工单名称： " + workflowName +"\n执行结果：" + workflowStatus
+                mailSender.sendEmail(strTitle, strContent, [objEngineer.email])
+                mailSender.sendEmail(strTitle, strContent, getattr(settings, 'MAIL_REVIEW_DBA_ADDR'))
         else:
             #不发邮件
             pass

--- a/sql/views.py
+++ b/sql/views.py
@@ -328,7 +328,7 @@ def cancel(request):
             workflowStatus = workflowDetail.status
             workflowName = workflowDetail.workflow_name
             objEngineer = users.objects.get(username=engineer)
-            objReviewMan = users.objects.get(username=reviewMan)
+            #objReviewMan = users.objects.get(username=reviewMan)
             strTitle = "SQL上线工单被拒绝执行 # " + str(workflowId)
             strContent = "发起人：" + engineer + "\n审核人：" + reviewMan + "\n工单地址：" + url + "\n工单名称： " + workflowName +"\n执行结果：" + workflowStatus +"\n提醒：此工单被拒绝执行，请登陆重新提交"
             mailSender.sendEmail(strTitle, strContent, [objEngineer.email])

--- a/sql/views.py
+++ b/sql/views.py
@@ -134,12 +134,13 @@ def submitSql(request):
     #获取所有审核人，当前登录用户不可以审核
     loginUser = request.session.get('login_username', False)
     reviewMen = users.objects.filter(role='审核人').exclude(username=loginUser)
-    if len(reviewMen) == 0:
-       context = {'errMsg': '审核人为0，请配置审核人'}
+    subReviewMen = users.objects.filter(role='副审核人').exclude(username=loginUser)
+    if len(reviewMen) == 0 and len(subReviewMen) == 0:
+       context = {'errMsg': '审核人为0，请配置审核人或副审核人'}
        return render(request, 'error.html', context) 
-    listAllReviewMen = [user.username for user in reviewMen]
+    #listAllReviewMen = [user.username for user in reviewMen]
   
-    context = {'currentMenu':'submitsql', 'dictAllClusterDb':dictAllClusterDb, 'reviewMen':reviewMen}
+    context = {'currentMenu':'submitsql', 'dictAllClusterDb':dictAllClusterDb, 'reviewMen':reviewMen, 'subReviewMen':subReviewMen}
     return render(request, 'submitSql.html', context)
 
 #提交SQL给inception进行解析

--- a/sql/views.py
+++ b/sql/views.py
@@ -245,7 +245,6 @@ def execute(request):
 
     #服务器端二次验证，正在执行人工审核动作的当前登录用户必须为审核人. 避免攻击或被接口测试工具强行绕过
     loginUser = request.session.get('login_username', False)
-    print(workflowDetail.review_man)
     if loginUser is None or loginUser not in json.loads(workflowDetail.review_man):
         context = {'errMsg': '当前登录用户不是审核人，请重新登录.'}
         return render(request, 'error.html', context)
@@ -279,18 +278,15 @@ def execute(request):
 
             #发一封邮件
             engineer = workflowDetail.engineer
-            listAllReviewMen = json.loads(workflowDetail.review_man)
+            reviewMan = workflowDetail.review_man
             workflowStatus = workflowDetail.status
             workflowName = workflowDetail.workflow_name
             objEngineer = users.objects.get(username=engineer)
             strTitle = "SQL上线工单执行完毕 # " + str(workflowId)
-            for reviewMan in listAllReviewMen:
-                if reviewMan == "":
-                    continue
-                objReviewMan = users.objects.filter(username=reviewMan)
-                strContent = "发起人：" + engineer + "\n审核人：" + reviewMan + "\n工单地址：" + url + "\n工单名称： " + workflowName +"\n执行结果：" + workflowStatus
-                mailSender.sendEmail(strTitle, strContent, [objEngineer.email])
-                mailSender.sendEmail(strTitle, strContent, getattr(settings, 'MAIL_REVIEW_DBA_ADDR'))
+            #objReviewMan = users.objects.filter(username=reviewMan)
+            strContent = "发起人：" + engineer + "\n审核人：" + reviewMan + "\n工单地址：" + url + "\n工单名称： " + workflowName +"\n执行结果：" + workflowStatus
+            mailSender.sendEmail(strTitle, strContent, [objEngineer.email])
+            mailSender.sendEmail(strTitle, strContent, getattr(settings, 'MAIL_REVIEW_DBA_ADDR'))
         else:
             #不发邮件
             pass
@@ -309,7 +305,7 @@ def cancel(request):
 
     #服务器端二次验证，如果正在执行终止动作的当前登录用户，不是发起人也不是审核人，则异常.
     loginUser = request.session.get('login_username', False)
-    if loginUser is None or (loginUser != workflowDetail.review_man and loginUser != workflowDetail.engineer):
+    if loginUser is None or (loginUser not in json.loads(workflowDetail.review_man) and loginUser != workflowDetail.engineer):
         context = {'errMsg': '当前登录用户不是审核人也不是发起人，请重新登录.'}
         return render(request, 'error.html', context)
 

--- a/sql/views.py
+++ b/sql/views.py
@@ -207,10 +207,13 @@ def autoreview(request):
 
                 #发一封邮件
                 strTitle = "新的SQL上线工单提醒 # " + str(workflowId)
-                strContent = "发起人：" + engineer + "\n审核人：" + reviewMan  + "\n工单地址：" + url + "\n工单名称： " + workflowName + "\n具体SQL：" + sqlContent
                 objEngineer = users.objects.get(username=engineer)
-                objReviewMan = users.objects.get(username=reviewMan)
-                mailSender.sendEmail(strTitle, strContent, [objReviewMan.email])
+                for reviewMan in listAllReviewMen:
+                    if reviewMan == "":
+                        continue
+                    strContent = "发起人：" + engineer + "\n审核人：" + reviewMan  + "\n工单地址：" + url + "\n工单名称： " + workflowName + "\n具体SQL：" + sqlContent
+                    objReviewMan = users.objects.get(username=reviewMan)
+                    mailSender.sendEmail(strTitle, strContent, [objReviewMan.email])
             else:
                 #不发邮件
                 pass
@@ -276,15 +279,15 @@ def execute(request):
 
             #发一封邮件
             engineer = workflowDetail.engineer
-            reviewMans = json.loads(workflowDetail.review_man)
+            listAllReviewMen = json.loads(workflowDetail.review_man)
             workflowStatus = workflowDetail.status
             workflowName = workflowDetail.workflow_name
             objEngineer = users.objects.get(username=engineer)
-            for reviewMan in reviewMans:
+            strTitle = "SQL上线工单执行完毕 # " + str(workflowId)
+            for reviewMan in listAllReviewMen:
                 if reviewMan == "":
                     continue
                 objReviewMan = users.objects.filter(username=reviewMan)
-                strTitle = "SQL上线工单执行完毕 # " + str(workflowId)
                 strContent = "发起人：" + engineer + "\n审核人：" + reviewMan + "\n工单地址：" + url + "\n工单名称： " + workflowName +"\n执行结果：" + workflowStatus
                 mailSender.sendEmail(strTitle, strContent, [objEngineer.email])
                 mailSender.sendEmail(strTitle, strContent, getattr(settings, 'MAIL_REVIEW_DBA_ADDR'))


### PR DESCRIPTION
0、背景：增加副审核人，方便在主审核人不在岗的时候由副审核人来审核工单
1、在用户提交工单页面submitSql.html增加了折叠面板提供副审核人(可选)，并在submitsql.js限制折叠面板首次隐藏和并在审核人名单里隐藏已经选为主审核人的标签
2、修改后端views.py,把接收到的审核人，副审核人放到list里，使用json序列化后存进工单表里；展示到detail页面时再反序列化后再展示
3、判断当前用户是否为审核人改用loginUser in json.loads(workflowDetail.review_man)
4、主副审核人，任意一人验证通过则工单交给inception执行