### PR TITLE
增加副审核人feature

### DIFF
--- a/sql/static/detail.html
+++ b/sql/static/detail.html
@@ -36,7 +36,7 @@
 							{{workflowDetail.engineer}}
 						</td>
 						<td>
-							{{workflowDetail.review_man}}
+                            {{listAllReviewMen.0}} {{listAllReviewMen.1}}
 						</td>
 						<td>
 							{{workflowDetail.cluster_name}}
@@ -139,7 +139,7 @@
 				</tbody>
 			</table>
 			{% if workflowDetail.status == '等待审核人审核' %}
-			{% if workflowDetail.review_man == loginUser %}
+            {% if loginUser in listAllReviewMen %}
 			<form action="/execute/" method="post" style="display:inline-block;">
 				{% csrf_token %}
 				<input type="hidden" name="workflowid" value="{{workflowDetail.id}}">

--- a/sql/static/submitSql.html
+++ b/sql/static/submitSql.html
@@ -43,6 +43,39 @@
 					{% endfor %}
 					</select>
 				</div>
+                <!--增加副审核人选项-->
+                <div class="form-group">
+                    <div class="panel-group" id="accordion">
+                        <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <h4 class="panel-title">
+                                    <a data-toggle="collapse"
+                                    data-parent="#accordion"
+                                       href="#collapseOne">
+                                        <i class="glyphicon-plus
+                                        glyphicon"></i>
+                                        增加副审核人（可选)
+                                    </a>
+                                </h4>
+                            </div>
+                            <div id="collapseOne" class="panel-collapse
+                            collapse">
+                                <div class="panel-body" style="margin-left:
+                                25px">
+                                    {% for man in reviewMen %}
+                                        <div class="radio" id="{{ man }}">
+                                            <input type="radio" id="radio1"
+                                            name="sub_review_man" value="{{
+                                            man }}" />
+                                            <label for="radio1"> {{ man }}
+                                            </label>
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 				<div class="form-group">
                     <input type="button" id="btn-autoreview" class="btn btn-info btn-lg" value="SQL检测" />
                     <button type="reset" class="btn btn-warning">清空选项</button>

--- a/sql/static/user/js/submitsql.js
+++ b/sql/static/user/js/submitsql.js
@@ -26,3 +26,8 @@ $("#btn-submitsql").click(function (){
 		formSubmit.submit();
 	}
 });
+
+$("#review_man").change(function review_man(){
+    var review_man = $(this).val();
+    $("div#" + review_man).hide();
+});


### PR DESCRIPTION
0、背景：增加副审核人，方便在主审核人不在岗的时候由副审核人来审核工单
1、在用户提交工单页面submitSql.html增加了折叠面板提供副审核人(可选)，并在submitsql.js限制折叠面板首次隐藏和并在审核人名单里隐藏已经选为主审核人的标签
2、修改后端views.py,把接收到的审核人，副审核人放到list里，使用json序列化后存进工单表里；展示到detail页面时再反序列化后再展示
3、判断当前用户是否为审核人改用loginUser in json.loads(workflowDetail.review_man)
4、主副审核人，任意一人验证通过则工单交给inception执行