### PR TITLE
增加工单修改功能

### DIFF
--- a/sql/static/detail.html
+++ b/sql/static/detail.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
 
 {% block content %}
-			<h4>单子名称：{{workflowDetail.workflow_name}}</h4>
+			<h4>单子名称：<span id="editWorkflowNname">{{workflowDetail.workflow_name}}</span></h4>
             <input type="hidden" id="workflowDetail_id" name="workflowid" value="{{workflowDetail.id}}">
+            <input type="hidden" id="editSqlContent" value="{{workflowDetail.sql_content}}"/>
 			<hr>	
 			<table class="table table-striped table-hover">
 				<thead>
@@ -158,7 +159,7 @@
                 <input type="hidden" name="workflowid" value="{{workflowDetail.id}}">
                 <input type="submit" id="btnRollback" type="button" class="btn btn-default" data-loading-text="Loading..." value="查看回滚SQL" />
             </form>
-			{% elif workflowDetail.status == '自动审核不通过' %}
-				<input type='button' class='btn btn-default' value='点此重新修改(其实是浏览器后退..)' onclick="history.back();" />
+			{% elif workflowDetail.status == '自动审核不通过' or workflowDetail.status == '人工终止流程' or workflowDetail.status == '执行中' or workflowDetail.status == '执行有异常' %}
+                <a type='button' id="btnEditSql" class='btn btn-warning' href="/editsql/">重新修改</a>
 			{% endif %}
 {% endblock content%}

--- a/sql/static/submitSql.html
+++ b/sql/static/submitSql.html
@@ -6,6 +6,7 @@
 
 	<form id="form-submitsql" action="/autoreview/" method="post" class="form-horizontal" role="form">
 		{% csrf_token %}
+        <input type="hidden" id="workflowid" name="workflowid"/>
 		<div class="col-md-8 column">
 			<textarea id="sql_content" name="sql_content" class="form-control" data-name="SQL内容" placeholder="请在此提交SQL，请以分号结尾。例如：use test; create table t1(id int)engine=innodb;" rows=20 required></textarea>
 		</div>
@@ -92,5 +93,13 @@
 		</div>
 	</div>
 </div>
-</div>	
+</div>
+<script type="text/javascript">
+    var pathname = window.location.pathname;
+    if (pathname == "/editsql/") {
+        document.getElementById('workflowid').value = sessionStorage.getItem('editWorkflowDetailId');
+        document.getElementById('workflow_name').value = sessionStorage.getItem('editWorkflowNname');
+        document.getElementById('sql_content').value = sessionStorage.getItem('editSqlContent');
+    }
+</script>
 {% endblock content %}

--- a/sql/static/user/js/detail.js
+++ b/sql/static/user/js/detail.js
@@ -144,3 +144,15 @@ function execute(){
             window.location.reload(true);
         },1000)
     }
+
+$(document).ready(function () {
+    $("#btnEditSql").click(function () {
+       var editWorkflowDetailId = $("#workflowDetail_id").val();
+       var editWorkflowNname = $("#editWorkflowNname").text();
+       var editSqlContent = $("#editSqlContent").val();
+       sessionStorage.setItem('editWorkflowDetailId', editWorkflowDetailId);
+       sessionStorage.setItem('editWorkflowNname', editWorkflowNname);
+       sessionStorage.setItem('editSqlContent', editSqlContent);
+    });
+
+});

--- a/sql/urls.py
+++ b/sql/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     url(r'^login/$', views.login, name='login'),
     url(r'^logout/$', views.logout, name='logout'),
     url(r'^submitsql/$', views.submitSql, name='submitSql'),
+    url(r'editsql/$', views.submitSql, name='editsql'),
     url(r'^allworkflow/$', views.allworkflow, name='allworkflow'),
     
     url(r'^autoreview/$', views.autoreview, name='autoreview'),

--- a/sql/views.py
+++ b/sql/views.py
@@ -144,6 +144,7 @@ def submitSql(request):
 
 #提交SQL给inception进行解析
 def autoreview(request):
+    workflowid = request.POST.get('workflowid')
     sqlContent = request.POST['sql_content']
     workflowName = request.POST['workflow_name']
     clusterName = request.POST['cluster_name']
@@ -182,18 +183,21 @@ def autoreview(request):
 
     #存进数据库里
     engineer = request.session.get('login_username', False)
-    newWorkflow = workflow()
-    newWorkflow.workflow_name = workflowName
-    newWorkflow.engineer = engineer
-    newWorkflow.review_man = json.dumps(listAllReviewMen)
-    newWorkflow.create_time = getNow()
-    newWorkflow.status = workflowStatus
-    newWorkflow.is_backup = isBackup
-    newWorkflow.review_content = jsonResult
-    newWorkflow.cluster_name = clusterName
-    newWorkflow.sql_content = sqlContent
-    newWorkflow.save()
-    workflowId = newWorkflow.id
+    if not workflowid:
+        Workflow = workflow()
+        Workflow.create_time = getNow()
+    else:
+        Workflow = workflow.objects.get(id=int(workflowid))
+    Workflow.workflow_name = workflowName
+    Workflow.engineer = engineer
+    Workflow.review_man = json.dumps(listAllReviewMen)
+    Workflow.status = workflowStatus
+    Workflow.is_backup = isBackup
+    Workflow.review_content = jsonResult
+    Workflow.cluster_name = clusterName
+    Workflow.sql_content = sqlContent
+    Workflow.save()
+    workflowId = Workflow.id
 
     #自动审核通过了，才发邮件
     if workflowStatus == Const.workflowStatus['manreviewing']:


### PR DESCRIPTION
以下四种状态下:
'自动审核不通过','人工终止流程','执行中','执行有异常'   提供工单修改功能。

1、使用h5的web缓存，保存工单id，工单name，sql conent
2、复用submitsql.html，加载时判断pathname，如果是editsql则从web缓存加载保护的变量并渲染summitsql.html
3、复用submitsql函数，判断工单id是否存在；如果不存在就创建新的工单，如果存在工单则修改已经存在的工单

测试通过